### PR TITLE
Update solr version; Point SHA_BASE to archive URL.

### DIFF
--- a/config/trln.yml
+++ b/config/trln.yml
@@ -1,6 +1,6 @@
 development:
         solr:
-                version: '5.4.1'
+                version: '5.5.2'
                 # this will be interpreted relative to Rails.root 
                 # unless it starts with a / 
                 install_dir: 'solr-install'
@@ -19,8 +19,8 @@ development:
 
 production:
         solr:
-                version: '5.4.1'
-                install_dir: /opt/solr/solr-5.4.1
+                version: '5.5.2'
+                install_dir: /opt/solr/solr-5.5.2
         traject:
                 cmdline_base : []
                 config_files: [ "traject-production.rb" ]

--- a/lib/solr.rb
+++ b/lib/solr.rb
@@ -179,7 +179,7 @@ class Fetcher
 
 	MIRROR_BASE = "https://www.apache.org/dyn/closer.lua/lucene/solr/%{version}"
 
-	SHA_BASE = "http://archive.apache.org/dist/lucene/solr/%{version}/solr-%{version}.tgz.sha1"
+	SHA_BASE = "https://archive.apache.org/dist/lucene/solr/%{version}/solr-%{version}.tgz.sha1"
 
 	@download_dir
 

--- a/lib/solr.rb
+++ b/lib/solr.rb
@@ -179,11 +179,11 @@ class Fetcher
 
 	MIRROR_BASE = "https://www.apache.org/dyn/closer.lua/lucene/solr/%{version}"
 
-	SHA_BASE = "http://www.us.apache.org/dist/lucene/solr/%{version}/solr-%{version}.tgz.sha1"
+	SHA_BASE = "http://archive.apache.org/dist/lucene/solr/%{version}/solr-%{version}.tgz.sha1"
 
 	@download_dir
 
-	@version = '5.4.1'
+	@version = '5.5.2'
 
 	@sha_uri
 
@@ -195,7 +195,7 @@ class Fetcher
 	
 	@install_dir
 	
-	def initialize(output_dir,version="5.4.1",download_dir=Dir.tmpdir)
+	def initialize(output_dir,version="5.5.2",download_dir=Dir.tmpdir)
 		@output_dir = output_dir
 		filename = "solr-#{version}.tgz"
 		@version = version

--- a/lib/tasks/trln.rake
+++ b/lib/tasks/trln.rake
@@ -38,7 +38,7 @@ desc "Custom tasks for TRLN"
 namespace :trln do
 	namespace :solr do
 		install_dir = ENV['SOLR_INSTALL_DIR'] || File.absolute_path(config[:solr][:install_dir], Rails.root)
-		solr_version = config[:solr][:version] || '5.4.1'
+		solr_version = config[:solr][:version] || '5.5.2'
 		solr_cmd = File.join(install_dir,"solr-#{solr_version}/bin/solr")
 		solr_port = config[:solr][:port] || 8983
 


### PR DESCRIPTION
SHA_BASE was pointed to http://www.us.apache.org/dist/lucene/solr/ which only lists the most recent solr 6 and solr 5 releases so the Solr installation task breaks every time there's an update to Solr. I switched this to the archive URL so it will continue to work after updates. Maybe there's a reason not to do this?
